### PR TITLE
Add CORS API to API endpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ function App() {
   const fetchSymbols = async () => {
     const API_KEY = process.env.REACT_APP_API_KEY;
     const url =
-      "http://api.exchangeratesapi.io/v1/symbols?access_key=" + API_KEY;
+      "https://cors-anywhere.herokuapp.com/http://api.exchangeratesapi.io/v1/symbols?access_key=" +
+      API_KEY;
     const response = await fetch(url);
     return response.json();
   };

--- a/src/components/Historical.tsx
+++ b/src/components/Historical.tsx
@@ -48,7 +48,10 @@ const Historical = ({ symbols }: { symbols: SymbolsList }) => {
   const fetchRates = async () => {
     const API_KEY = process.env.REACT_APP_API_KEY;
     const url =
-      "http://api.exchangeratesapi.io/v1/" + date + "?access_key=" + API_KEY;
+      "https://cors-anywhere.herokuapp.com/http://api.exchangeratesapi.io/v1/" +
+      date +
+      "?access_key=" +
+      API_KEY;
     const response = await fetch(url);
     return response.json();
   };

--- a/src/components/Latest.tsx
+++ b/src/components/Latest.tsx
@@ -41,7 +41,8 @@ const Latest = ({ symbols }: { symbols: SymbolsList }) => {
   const fetchRates = async () => {
     const API_KEY = process.env.REACT_APP_API_KEY;
     const url =
-      "http://api.exchangeratesapi.io/v1/latest?access_key=" + API_KEY;
+      "https://cors-anywhere.herokuapp.com/http://api.exchangeratesapi.io/v1/latest?access_key=" +
+      API_KEY;
     const response = await fetch(url);
     return response.json();
   };


### PR DESCRIPTION
Exchange rates API does not provide HTTPS encryption, adding the
CORS API to the fetch allows it to bypass browsers blocking mixed
active content